### PR TITLE
Option to erase VFS before use

### DIFF
--- a/cores/portduino/simulated/SimHardwareI2C.h
+++ b/cores/portduino/simulated/SimHardwareI2C.h
@@ -41,12 +41,12 @@ public:
   virtual uint8_t endTransmission(void) { return endTransmission(true); }
 
   virtual uint8_t requestFrom(uint8_t address, size_t len, bool stopBit) {
-    notImplemented("requestFrom");
+    // notImplemented("requestFrom");
     return 0;
   }
 
   virtual uint8_t requestFrom(uint8_t address, size_t len) {
-    notImplemented("requestFrom");
+    // notImplemented("requestFrom");
     return 0;
   }
 


### PR DESCRIPTION
In order for a clean start of the Linux native application, the previous VFS should be erased. I use this to let multiple instances communicate, see also my [PR in Meshtastic-device.](https://github.com/meshtastic/Meshtastic-device/pull/1737) 