### PR TITLE
Fix for case when `random` is called with same arguments

### DIFF
--- a/cores/portduino/linux/LinuxCommon.cpp
+++ b/cores/portduino/linux/LinuxCommon.cpp
@@ -25,7 +25,12 @@ void yield(void) { sched_yield(); }
 
 long random(long max) { return random(0, max); }
 
-long random(long min, long max) { return rand() % (max - min) + min; }
+long random(long min, long max) { 
+  if (min >= max) {
+    return min;
+  }
+  return rand() % (max - min) + min; 
+}
 
 void randomSeed(unsigned long s) { srand(s); }
 


### PR DESCRIPTION
Modulo of 0 results in undefined behavior. This logic is how it's done in the Arduino core.