### PR TITLE
Check for `serial_port` in `LinuxSerial::end()`

### DIFF
--- a/cores/portduino/linux/LinuxSerial.cpp
+++ b/cores/portduino/linux/LinuxSerial.cpp
@@ -22,32 +22,32 @@ namespace arduino {
         serial_port = open(path.c_str(), O_RDWR);
         tcgetattr(serial_port, &tty);
 
-          tty.c_cflag &= ~PARENB; // Clear parity bit, disabling parity (most common)
-  tty.c_cflag &= ~CSTOPB; // Clear stop field, only one stop bit used in communication (most common)
-  tty.c_cflag &= ~CSIZE; // Clear all bits that set the data size 
-  tty.c_cflag |= CS8; // 8 bits per byte (most common)
-  tty.c_cflag &= ~CRTSCTS; // Disable RTS/CTS hardware flow control (most common)
-  tty.c_cflag |= CREAD | CLOCAL; // Turn on READ & ignore ctrl lines (CLOCAL = 1)
+        tty.c_cflag &= ~PARENB; // Clear parity bit, disabling parity (most common)
+        tty.c_cflag &= ~CSTOPB; // Clear stop field, only one stop bit used in communication (most common)
+        tty.c_cflag &= ~CSIZE; // Clear all bits that set the data size 
+        tty.c_cflag |= CS8; // 8 bits per byte (most common)
+        tty.c_cflag &= ~CRTSCTS; // Disable RTS/CTS hardware flow control (most common)
+        tty.c_cflag |= CREAD | CLOCAL; // Turn on READ & ignore ctrl lines (CLOCAL = 1)
 
-  tty.c_lflag &= ~ICANON;
-  tty.c_lflag &= ~ECHO; // Disable echo
-  tty.c_lflag &= ~ECHOE; // Disable erasure
-  tty.c_lflag &= ~ECHONL; // Disable new-line echo
-  tty.c_lflag &= ~ISIG; // Disable interpretation of INTR, QUIT and SUSP
-  tty.c_iflag &= ~(IXON | IXOFF | IXANY); // Turn off s/w flow ctrl
-  tty.c_iflag &= ~(IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL); // Disable any special handling of received bytes
+        tty.c_lflag &= ~ICANON;
+        tty.c_lflag &= ~ECHO; // Disable echo
+        tty.c_lflag &= ~ECHOE; // Disable erasure
+        tty.c_lflag &= ~ECHONL; // Disable new-line echo
+        tty.c_lflag &= ~ISIG; // Disable interpretation of INTR, QUIT and SUSP
+        tty.c_iflag &= ~(IXON | IXOFF | IXANY); // Turn off s/w flow ctrl
+        tty.c_iflag &= ~(IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL); // Disable any special handling of received bytes
 
-  tty.c_oflag &= ~OPOST; // Prevent special interpretation of output bytes (e.g. newline chars)
-  tty.c_oflag &= ~ONLCR; // Prevent conversion of newline to carriage return/line feed
-  // tty.c_oflag &= ~OXTABS; // Prevent conversion of tabs to spaces (NOT PRESENT ON LINUX)
-  // tty.c_oflag &= ~ONOEOT; // Prevent removal of C-d chars (0x004) in output (NOT PRESENT ON LINUX)
+        tty.c_oflag &= ~OPOST; // Prevent special interpretation of output bytes (e.g. newline chars)
+        tty.c_oflag &= ~ONLCR; // Prevent conversion of newline to carriage return/line feed
+        // tty.c_oflag &= ~OXTABS; // Prevent conversion of tabs to spaces (NOT PRESENT ON LINUX)
+        // tty.c_oflag &= ~ONOEOT; // Prevent removal of C-d chars (0x004) in output (NOT PRESENT ON LINUX)
 
-  tty.c_cc[VTIME] = 0;    // don't wait
-  tty.c_cc[VMIN] = 0;
+        tty.c_cc[VTIME] = 0;    // don't wait
+        tty.c_cc[VMIN] = 0;
 
-  cfsetispeed(&tty, baudrate);
-cfsetospeed(&tty, baudrate);
-tcsetattr(serial_port, TCSANOW, &tty);
+        cfsetispeed(&tty, baudrate);
+        cfsetospeed(&tty, baudrate);
+        tcsetattr(serial_port, TCSANOW, &tty);
 
     }
 
@@ -58,7 +58,8 @@ tcsetattr(serial_port, TCSANOW, &tty);
     }
 
     void LinuxSerial::end() {
-        close(serial_port);
+        if (serial_port != -1)
+            close(serial_port);
     }
 
     int LinuxSerial::available(void) {
@@ -93,7 +94,7 @@ tcsetattr(serial_port, TCSANOW, &tty);
 
 
     //simulated serial for log output:
-        void SimSerial::begin(unsigned long baudrate, uint16_t config) {
+    void SimSerial::begin(unsigned long baudrate, uint16_t config) {
         // Ignore baudrate and config on linux (for now)
         // FIXME open file descriptor
     }

--- a/cores/portduino/linux/LinuxSerial.h
+++ b/cores/portduino/linux/LinuxSerial.h
@@ -10,7 +10,7 @@
 
 namespace arduino {
     class LinuxSerial : public HardwareSerial {
-        int serial_port;
+        int serial_port = -1;
         std::string path;
     public:
         virtual void begin(unsigned long baudrate) { begin(baudrate, SERIAL_8N1 ); }


### PR DESCRIPTION
Following up from https://github.com/meshtastic/firmware/pull/3033. The call to `Serial1.end()` closed file descriptor 0 (`stdin`) on my machine. When unifying the Linux native targets, this will be important to fix.