### PR TITLE
Add I2C readBytes()

### DIFF
--- a/ArduinoCore-API/api/HardwareI2C.h
+++ b/ArduinoCore-API/api/HardwareI2C.h
@@ -17,7 +17,7 @@
 */
 
 #pragma once
-
+#define TwoWire_h
 #include <inttypes.h>
 #include "Stream.h"
 

--- a/cores/portduino/linux/LinuxHardwareI2C.cpp
+++ b/cores/portduino/linux/LinuxHardwareI2C.cpp
@@ -57,9 +57,22 @@ namespace arduino {
     }
 
     int LinuxHardwareI2C::read() {
-        if (::read(i2c_file, buf, 1) == -1)
+        int tmpBuf = 0;
+        if (::read(i2c_file, &tmpBuf, 1) == -1)
             return -1;
-        return buf[0];
+        return tmpBuf;
+    }
+
+    size_t LinuxHardwareI2C::readBytes(char *buffer, size_t length) {
+        int bytes_read = 0;
+
+        if (length == 0) {
+            return length;
+        } else {
+            bytes_read = ::read(i2c_file, buffer, length);
+            if ( bytes_read < 0) bytes_read = 0;
+        }
+        return bytes_read;
     }
 
     int LinuxHardwareI2C::available() {

--- a/cores/portduino/linux/LinuxHardwareI2C.h
+++ b/cores/portduino/linux/LinuxHardwareI2C.h
@@ -67,6 +67,8 @@ public:
     return 0;
   }
 
+  virtual size_t readBytes( char *buffer, size_t length);
+
   virtual int peek() {
     notImplemented("i2cpeek");
     return -1;


### PR DESCRIPTION
This adds the TwoWire_h define, just like the Wire library does, to make an ifdef check work in Lovyan. Then populates a readBytes() i2c function, to read multiple bytes at once, which gets an i2c touchscreen working in Lovyan. 