### PR TITLE
Variable number of gpios

### DIFF
--- a/ArduinoCore-API/api/HardwareSPI.h
+++ b/ArduinoCore-API/api/HardwareSPI.h
@@ -22,6 +22,7 @@
 #include <inttypes.h>
 #include "Stream.h"
 #include "SPIChip.h"
+#include <memory>
 
 #define SPI_HAS_TRANSACTION
 
@@ -126,7 +127,7 @@ class HardwareSPI
 
     virtual void end();
   protected:
-    SPIChip *spiChip = nullptr;
+    std::shared_ptr <SPIChip> spiChip = nullptr;
 };
 
 // Alias SPIClass to HardwareSPI since it's already the defacto standard for SPI classe name

--- a/cores/portduino/PortduinoGPIO.cpp
+++ b/cores/portduino/PortduinoGPIO.cpp
@@ -10,20 +10,22 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <vector>
 
 // #include "linux/gpio/classic/GPIOChip.h"
 
-#define NUM_GPIOS 64
+int NUM_GPIOS;
 
 bool realHardware = false;
 
-static GPIOPinIf *pins[NUM_GPIOS];
+std::vector<GPIOPinIf*> pins;
 
 
 /** By default we assign simulated GPIOs to all pins, later applications can customize this in portduinoSetup */
-void gpioInit() {
+void gpioInit(int _num_gpios) {
+  NUM_GPIOS = _num_gpios;
   for(size_t i = 0; i < NUM_GPIOS; i++)
-    pins[i] = new SimGPIOPin(i, "Unbound");
+    pins.push_back( new SimGPIOPin(i, "Unbound"));
 }
 
 void gpioIdle() {

--- a/cores/portduino/PortduinoGPIO.h
+++ b/cores/portduino/PortduinoGPIO.h
@@ -207,7 +207,7 @@ public:
     SimGPIOPin(pin_size_t n, String _name) : GPIOPin(n, _name) {}
 };
 
-void gpioInit();
+void gpioInit(int _num_gpios = 64);
 void gpioIdle();
 
 /// Assign an implementation to a specific pin


### PR DESCRIPTION
We've had users trying to run meshtasticd on other "fruit" boards, and have run into the problem that some boards use high number GPIOs. This is a simple fix, that allows setting the NUM_GPIOS in the gpioInit() function.