### PR TITLE
Work on reboot()

### DIFF
--- a/cores/portduino/main.cpp
+++ b/cores/portduino/main.cpp
@@ -8,6 +8,9 @@
 #include <sys/ioctl.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
+#include <cerrno>
+#include <iostream>
+#include <cstring>
 
 #ifdef USE_X11
 #include <thread>
@@ -154,7 +157,10 @@ void portduinoAddArguments(const struct argp_child &child,
 }
 
 void reboot() {
-  execv(progArgv[0], progArgv);
+  int err = execv(progArgv[0], progArgv);
+  printf("execv() returned %i!\n", err);
+  std::cout << "error: " << std::strerror(errno) << '\n';
+  exit(EXIT_FAILURE);
 }
 
 int main(int argc, char *argv[]) {

--- a/cores/portduino/main.cpp
+++ b/cores/portduino/main.cpp
@@ -164,7 +164,17 @@ void reboot() {
 }
 
 int main(int argc, char *argv[]) {
-  progArgv = argv;
+
+  progArgv = (char**) malloc((argc + 1) * sizeof(char*)); // New pointer array, argc + 1 to hold the final null
+  int j = 0;
+  for (int i = 0; i < argc; i++) { // iterate through the arguments, stripping out the erase command, to avoid erase on reboot()
+    if (strcmp(argv[i], "-e") != 0 && strcmp(argv[i], "--erase") != 0  ) {
+      progArgv[j] = argv[i];
+      j++;
+    }
+  }
+  progArgv[j] = NULL;
+
   portduinoCustomInit();
 
   auto *args = &portduinoArguments;
@@ -195,6 +205,7 @@ int main(int argc, char *argv[]) {
     int status = mkdir(fsRoot.c_str(), 0700);
     if (status != 0 && errno == EEXIST && args->erase) {
       // Remove contents of existing VFS root directory
+      std::cout << "Erasing virtual Filesystem!" << std::endl;
       rmrf(const_cast<char*>(fsRoot.c_str())); 
     }
 


### PR DESCRIPTION
We're seeing instances of segfaults around reboot() calls, and one of the possibilities is that our execv() call is failing, so add error handling to that.

Then it's rather annoying when running with the -e or --erase command, to try to change a setting, only to have it erased on reboot(), so we strip that flag before reboot().