### PR TITLE
Fix a gpio memory leak on shutdown

### DIFF
--- a/cores/portduino/PortduinoGPIO.h
+++ b/cores/portduino/PortduinoGPIO.h
@@ -15,6 +15,7 @@
 class GPIOPinIf
 {
 public:
+    virtual ~GPIOPinIf() = 0;
     virtual pin_size_t getPinNum() const = 0;
 
     /** Called to read from a pin and if the pin has changed state possibly call an ISR, also changes

--- a/cores/portduino/linux/gpio/LinuxGPIOPin.cpp
+++ b/cores/portduino/linux/gpio/LinuxGPIOPin.cpp
@@ -104,7 +104,6 @@ static struct gpiod_chip *chip_open_by_name(const char *name)
  * Try to find the specified linux gpio line, throw exception if not found
  */
 gpiod_line *LinuxGPIOPin::getLine(const char *chipLabel, const char *linuxPinName) {
-	struct gpiod_chip *chip;
 	std::string path = "/dev/";
 	path += chipLabel;
   if (access(path.c_str(), R_OK) == 0) {
@@ -181,7 +180,6 @@ gpiod_line *LinuxGPIOPin::getLine(const char *chipLabel, const char *linuxPinNam
  * Try to find the specified linux gpio line, throw exception if not found
  */
 gpiod_line *LinuxGPIOPin::getLine(const char *chipLabel, const int linuxPinNum) {
-	struct gpiod_chip *chip;
 	std::string path = "/dev/";
 	path += chipLabel;
   if (access(path.c_str(), R_OK) == 0) {
@@ -270,7 +268,7 @@ LinuxGPIOPin::LinuxGPIOPin(pin_size_t n, const char *chipLabel,
 
 LinuxGPIOPin::~LinuxGPIOPin() { 
     gpiod_line_release(line); 
-    // FIXME must call gpiod_chip_unref(chip);
+    gpiod_chip_close(chip);
 }
 
 /// Read the low level hardware for this pin

--- a/cores/portduino/linux/gpio/LinuxGPIOPin.h
+++ b/cores/portduino/linux/gpio/LinuxGPIOPin.h
@@ -29,6 +29,9 @@ class LinuxGPIOPin : public GPIOPin {
   /// Our GPIO line
   struct gpiod_line *line;
 
+  /// Chip structure associated with the line
+  struct gpiod_chip *chip;
+
 public:
 
   /**


### PR DESCRIPTION
On shutdown, LinuxGPIOPin, SimGPIOPin, and gpiod_chip are not released, thus clogging -fsanitize=address final output.