### PR TITLE
musl compatibility

### DIFF
--- a/cores/portduino/FS/vfs_api.h
+++ b/cores/portduino/FS/vfs_api.h
@@ -19,7 +19,7 @@
 #include "FSImpl.h"
 
 extern "C" {
-#include <sys/unistd.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include <dirent.h>
 }


### PR DESCRIPTION
Allows framework-portduino to compile successfully with `musl` so that it can be used with [buildroot-meshtastic](https://github.com/vidplace7/buildroot-meshtastic).

musl does not include `<sys/unistd.h>`, this switches includes to standard `<unistd.h>`

Cousin PR: https://github.com/meshtastic/firmware/pull/5219