### PR TITLE
Rename the getMacAddr function. Helps with adding the mac to config

### DIFF
--- a/cores/portduino/Arduino.h
+++ b/cores/portduino/Arduino.h
@@ -51,6 +51,6 @@ void portduinoAddArguments(const struct argp_child &child, void *childArguments)
  * write a 6 byte 'macaddr'/unique ID to the dmac parameter
  * This value can be customized with the --macaddr parameter and it defaults to 00:00:00:00:00:01
  */
-void getMacAddr(uint8_t *dmac);
+void _getMacAddr(uint8_t *dmac);
 void reboot();
 #endif

--- a/cores/portduino/main.cpp
+++ b/cores/portduino/main.cpp
@@ -89,7 +89,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   return 0;
 }
 
-void getMacAddr(uint8_t *dmac) {
+void _getMacAddr(uint8_t *dmac) {
 
   dmac[0] = 0x80;
   dmac[1] = 0;


### PR DESCRIPTION
Looking to add MACAddr as a config.yaml option. This makes for a much easier way to hook the call, to override the value.