### PR TITLE
fix crash in printf

### DIFF
--- a/cores/portduino/PortduinoPrint.cpp
+++ b/cores/portduino/PortduinoPrint.cpp
@@ -6,11 +6,12 @@
 #define MAX_STR_LEN 256
 
 size_t Print::printf(const char *format, ...) {
-  char buf[MAX_STR_LEN]; // FIXME, this burns a lot of stack, but on
+    char buf[MAX_STR_LEN]; // FIXME, this burns a lot of stack, but on
                                 // Linux that is fine, TBD on MyNewt
-  va_list args;
-  va_start(args, format);
-  vsnprintf(buf, sizeof(buf), format, args);
-  write(buf);
-  va_end(args);
+    va_list args;
+    va_start(args, format);
+    size_t n = vsnprintf(buf, sizeof(buf), format, args);
+    write(buf);
+    va_end(args);
+    return n;
 }


### PR DESCRIPTION
See #31. Fixes #30 by adding missing return statement.