### PR TITLE
Fix crash on startup in itoa.cpp

### DIFF
--- a/cores/portduino/itoa.cpp
+++ b/cores/portduino/itoa.cpp
@@ -1,20 +1,37 @@
-#include "itoa.h"
-#include <stdlib.h>
+#include <itoa.h>
+#include <string>
+#include <stdexcept>
+#include <stdio.h>
 
-// FIXME - implement this
 
-char *itoa(int value, char *string, int radix) {
-    return NULL;
+std::string radixToFmtString(int const radix)
+{
+    if (radix == 8)  return std::string("%o");
+    else if (radix == 10) return std::string("%d");
+    else if (radix == 16) return std::string("%X");
+    else throw std::runtime_error("Invalid radix.");
 }
 
-char *ltoa(long value, char *string, int radix) {
-    return NULL;
+char * itoa(int value, char * str, int radix)
+{
+    sprintf(str, radixToFmtString(radix).c_str(), value);
+    return str;
 }
 
-char *utoa(unsigned value, char *string, int radix) {
-    return NULL;
+char * ltoa(long value, char * str, int radix)
+{
+    sprintf(str, radixToFmtString(radix).c_str(), value);
+    return str;
 }
 
-char *ultoa(unsigned long value, char *string, int radix) {
-    return NULL;
+char * utoa(unsigned value, char *str, int radix)
+{
+    sprintf(str, radixToFmtString(radix).c_str(), value);
+    return str;
+}
+
+char * ultoa(unsigned long value, char * str, int radix)
+{
+    sprintf(str, radixToFmtString(radix).c_str(), value);
+    return str;
 }


### PR DESCRIPTION
Fix crash on startup due to missing/dummy implementation:

```
DEBUG | 20:02:08 0 [DeviceUI]     home_wlan_off_image: 3888
DEBUG | 20:02:08 0 [DeviceUI]     home_bluetooth_off_button_image: 5184
DEBUG | 20:02:08 0 [DeviceUI]     node_router_image: 2304
=================================================================
==86398==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fe17ac65639 at pc 0x7fe17dc46ce6 bp 0x7ffdb3993820 sp 0x7ffdb3992fe0
READ of size 33 at 0x7fe17ac65639 thread T0
    #0 0x7fe17dc46ce5 in strlen.part.0 (/lib64/libasan.so.8+0x46ce5) (BuildId: 5294bd2731fcae07af92dfea7808576c57d53bc9)
    #1 0x7f0653 in arduino::String::concat(unsigned long) /home/manuel/.platformio/packages/framework-portduino/cores/arduino/api/String.cpp:324
    #2 0x7f0afc in arduino::operator+(arduino::StringSumHelper const&, unsigned long) /home/manuel/.platformio/packages/framework-portduino/cores/arduino/api/String.cpp:409
    #3 0x67d6f4 in Thread::Thread(void (*)(), unsigned long) .pio/libdeps/native-tft-debug/Thread/Thread.cpp:12
    #4 0x545c0a in concurrency::OSThread::OSThread(char const*, unsigned int, ThreadController*) src/concurrency/OSThread.cpp:30
    #5 0x5f785b in NodeInfoModule::NodeInfoModule() src/modules/NodeInfoModule.cpp:97
    #6 0x5efef3 in setupModules() src/modules/Modules.cpp:106
    #7 0x57bec4 in setup src/main.cpp:872
    #8 0x802b5c in main /home/manuel/.platformio/packages/framework-portduino/cores/portduino/main.cpp:216
    #9 0x7fe17ce0f247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: b6c381bfdcb5e08ea82c1c39cf16580181fb6cfc)
    #10 0x7fe17ce0f30a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x330a) (BuildId: b6c381bfdcb5e08ea82c1c39cf16580181fb6cfc)
    #11 0x404dd4 in _start (/home/manuel/Documents/PlatformIO/Projects/meshtastic-latest/.pio/build/native-tft-debug/program+0x404dd4) (BuildId: 4097bc2cc626e919df9a5d1756ced9ffa51a5c56)

Address 0x7fe17ac65639 is located in stack of thread T0 at offset 57 in frame
    #0 0x7f05db in arduino::String::concat(unsigned long) /home/manuel/.platformio/packages/framework-portduino/cores/arduino/api/String.cpp:321

  This frame has 1 object(s):
    [32, 57) 'buf' (line 322) <== Memory access at offset 57 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/lib64/libasan.so.8+0x46ce5) (BuildId: 5294bd2731fcae07af92dfea7808576c57d53bc9) in strlen.part.0
```

I've copied the implementation from `.platformio/packages/framework-arduinopico/ArduinoCore-API/test/src/itoa.cpp` which fixes the crash.