### PR TITLE
int must be initialized to 0 because it is larger than a single byte read from the serial port

### DIFF
--- a/cores/portduino/linux/LinuxSerial.cpp
+++ b/cores/portduino/linux/LinuxSerial.cpp
@@ -190,7 +190,7 @@ namespace arduino {
     }
 
     int LinuxSerial::read(void) {
-        int buf;
+        int buf = 0;
         ::read(serial_port, &buf, 1);
         return buf;
     }


### PR DESCRIPTION
I provide this fix because I encountered a bug using LinuxSerial code on Raspberry Pi 5 (aarch64): int contained spurious data in the higher bytes.