### PR TITLE
allow multiple processes to all bind to the same multicast 2tuple

### DIFF
--- a/cores/portduino/AsyncUDP.h
+++ b/cores/portduino/AsyncUDP.h
@@ -77,6 +77,7 @@ private:
 
     uv_loop_t _loop;
     uv_udp_t _socket;
+    int _fd;
     uv_async_t _async;
 
 public:


### PR DESCRIPTION
I've tested it with 2 Linux Native ←→ 1 ESP32 and it just works.

This is the second try of this, the previous patch relied on the UV_UDP_REUSEPORT option which was added in 1.49.0 which most of our targets did not support.
    
This works around this by initiliazing the file descriptor manually, and using setsockopt, this change the baseline from libuv 1.49.0 to Linux 3.9 which is far older and supported target.

This remove the need to use hacky workarounds like docker networking. Note: by design you still need to pass the -p flag to meshtasticd for the TCP port, this only impact the multicast mesh.