### PR TITLE
zero fields before using them in udp multicast

### DIFF
--- a/cores/portduino/AsyncUDP.cpp
+++ b/cores/portduino/AsyncUDP.cpp
@@ -11,6 +11,9 @@ void _asyncudp_async_cb(uv_async_t *handle) {
 AsyncUDP::AsyncUDP() {
     _handler = NULL;
     _connected = false;
+    _fd = 0;
+    _quit.store(false);
+
     uv_loop_init(&_loop);
     _async.data = this;
     uv_async_init(&_loop, &_async, _asyncudp_async_cb);


### PR DESCRIPTION
As a Go programer I expect all datatypes to have a default constructor initializing to a zero value, because in Go all new values always have a all zeros default value.

When I implemented ce9335d6857ca5e720965a87fd1b6f07512c2ce9 I forgot to initialize _fd & _quit to zero values.

This would have been caught by clang's UB sanitizers, we should make a *SAN build.

Needed for meshtastic/firmware#6683