### PR TITLE
AsyncUDP: keep track of the last sent packet and skip it while LOOPing

### DIFF
--- a/cores/portduino/AsyncUDP.cpp
+++ b/cores/portduino/AsyncUDP.cpp
@@ -3,9 +3,16 @@
 #include <sys/socket.h>
 #include "Utility.h"
 
+#define LOOP_TIMER_CHECK_TIMEOUT_MS 100
+
 void _asyncudp_async_cb(uv_async_t *handle) {
     AsyncUDP *udp = (AsyncUDP *)handle->data;
     udp->_DO_NOT_CALL_async_cb();
+}
+
+void _asyncudp_timer_cb(uv_timer_t *handle) {
+    AsyncUDP *udp = (AsyncUDP *)handle->data;
+    udp->_DO_NOT_CALL_timer_cb();
 }
 
 AsyncUDP::AsyncUDP() {
@@ -17,6 +24,8 @@ AsyncUDP::AsyncUDP() {
     uv_loop_init(&_loop);
     _async.data = this;
     uv_async_init(&_loop, &_async, _asyncudp_async_cb);
+    _timer.data = this;
+    uv_timer_init(&_loop, &_timer);
 }
 
 AsyncUDP::~AsyncUDP() {
@@ -50,6 +59,12 @@ void _asyncudp_on_read_cb(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, 
 
 void AsyncUDP::_DO_NOT_CALL_uv_on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const struct sockaddr *addr, unsigned flags) {
     if (nread <= 0) {
+        if (_waitingToBeLooped) {
+            // we are waiting to receive a packet yet we just exhausted the receive buffer.
+            // This can happen if we are unlucky and this happens to run while we were sending a packet.
+            // Or this happens because the receive buffer was full and the packet we are waiting for was dropped.
+            _emptiedBuffer = true;
+        }
         return;
     }
     _handlerMutex.lock();
@@ -57,6 +72,7 @@ void AsyncUDP::_DO_NOT_CALL_uv_on_read(uv_udp_t *handle, ssize_t nread, const uv
     _handlerMutex.unlock();
     if (_waitingToBeLooped && nread == _waitingToBeLooped->len && memcmp(buf->base, _waitingToBeLooped->data, nread) == 0) {
         _waitingToBeLooped = std::unique_ptr<asyncUDPSendTask>();
+        uv_timer_stop(&_timer);
         _attemptWrite();
     } else {
         if (h) {
@@ -174,10 +190,12 @@ void AsyncUDP::_attemptWrite() {
         _sendQueue.pop_back();
         _sendQueueMutex.unlock();
         _doWrite(task->data, task->len, task->addr, task->port);
-        _sendQueueMutex.lock();
         _waitingToBeLooped = std::move(task);
+        _emptiedBuffer = false;
+        uv_timer_start(&_timer, _asyncudp_timer_cb, LOOP_TIMER_CHECK_TIMEOUT_MS, LOOP_TIMER_CHECK_TIMEOUT_MS);
+    } else {
+        _sendQueueMutex.unlock();
     }
-    _sendQueueMutex.unlock();
 }
 
 void AsyncUDP::_DO_NOT_CALL_async_cb() {
@@ -191,6 +209,22 @@ void AsyncUDP::_DO_NOT_CALL_async_cb() {
         addr_str[maxIpLength] = '\0';
         uv_udp_set_membership(&_socket, addr_str, NULL, UV_LEAVE_GROUP);
         uv_stop(&_loop);
+    }
+}
+
+void AsyncUDP::_DO_NOT_CALL_timer_cb() {
+    if (!_waitingToBeLooped) {
+        uv_timer_stop(&_timer);
+        return;
+    }
+    if (_emptiedBuffer) {
+        // We waited for LOOP_TIMER_CHECK_TIMEOUT_MS; we exhausted the receive buffer yet we did not receive the LOOPed packet we were waiting for.
+        // It is fair to say we will most likely never receive it.
+        // Probably it was dropped by the kernel because the receive buffer was full.
+        _waitingToBeLooped = std::unique_ptr<asyncUDPSendTask>();
+        uv_timer_stop(&_timer);
+    } else {
+        // We are still waiting for the packet to be LOOPed back but we havn't yet exhausted the receive buffer.
     }
 }
 

--- a/cores/portduino/AsyncUDP.h
+++ b/cores/portduino/AsyncUDP.h
@@ -69,10 +69,12 @@ private:
     // the queue is used because uv_udp_send is not threadsafe and uv_async can merge multiple calls into one callback
     std::vector<std::unique_ptr<asyncUDPSendTask>> _sendQueue;
 
+    // Theses must be accessed from the uv loop.
     // _waitingToBeLooped is used to wait for a sent packet to be looped back before we send an other one.
     // This allows the recv callback to omit sent packets.
-    // It must be accessed from the uv loop.
     std::unique_ptr<asyncUDPSendTask> _waitingToBeLooped;
+    bool _emptiedBuffer = false;
+    uv_timer_t _timer;
 
     std::atomic<bool> _quit;
     std::thread _ioThread;
@@ -112,6 +114,7 @@ public:
     // do not call, used internally as callback from libuv's C callback
     void _DO_NOT_CALL_uv_on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const struct sockaddr *addr, unsigned flags);
     void _DO_NOT_CALL_async_cb();
+    void _DO_NOT_CALL_timer_cb();
 
 private:
     // _attemptWrite must be accessed from the uv loop.


### PR DESCRIPTION
This means we don't invoke the receive handler for packets we send.

Closes meshtastic/firmware#7661 (the only needed change in `meshtastic/firmware` is to bump the dependencies to use this commit)