### PR TITLE
Add support for symbolic links in openNextFile function

### DIFF
--- a/cores/portduino/FS/vfs_api.cpp
+++ b/cores/portduino/FS/vfs_api.cpp
@@ -397,7 +397,7 @@ FileImplPtr VFSFileImpl::openNextFile(const char* mode)
     if(file == NULL) {
         return FileImplPtr();
     }
-    if(file->d_type != DT_REG && file->d_type != DT_DIR) {
+    if(file->d_type != DT_REG && file->d_type != DT_DIR && file->d_type != DT_LNK) {
         return openNextFile(mode);
     }
     String fname = String(file->d_name);


### PR DESCRIPTION
This pull request makes a small change to the `VFSFileImpl::openNextFile` method to improve support for symbolic links in the virtual file system implementation.

- Now allows files of type `DT_LNK` (symbolic links) to be opened in addition to regular files and directories, by updating the type check in `vfs_api.cpp`.

We need to support symlinked directories for VFS objects in order to support Homebrew packaging paradigms (they LOVE symlinks to the Cellar)

Untested :sweat_smile: 