### PR TITLE
Fix LinuxHardwareI2C fd lifecycle

### DIFF
--- a/cores/portduino/linux/LinuxHardwareI2C.cpp
+++ b/cores/portduino/linux/LinuxHardwareI2C.cpp
@@ -36,12 +36,14 @@ namespace arduino {
     void LinuxHardwareI2C::begin(const char * device) {
         if (!hasBegun) {
             i2c_file = open(device, O_RDWR);
-            hasBegun = true;
+            if (i2c_file >= 0)
+                hasBegun = true;
         }
     }
     void LinuxHardwareI2C::end() {
         if (hasBegun) {
             close(i2c_file);
+            i2c_file = -1;
             hasBegun = false;
         }
     }

--- a/cores/portduino/linux/LinuxHardwareI2C.h
+++ b/cores/portduino/linux/LinuxHardwareI2C.h
@@ -20,7 +20,7 @@ enum ResultI2c {
 };
 
 class LinuxHardwareI2C : public HardwareI2C {
-  int i2c_file = 0;
+  int i2c_file = -1; // unopened: fail fast instead of operating on stdin/stdout
 
 public:
   void begin(const char* device);


### PR DESCRIPTION
- Default i2c_file to -1; was 0 (stdin), so pre-begin() Wire ops blocked on stdin instead of failing fast.
- Only set hasBegun when open() succeeds, so a failed begin() can retry.
- Reset i2c_file to -1 in end() to avoid using a stale (or reused) fd.
- Fix #71
