### PR TITLE
Fix Darwin multicast loopback by binding to INADDR_ANY

### DIFF
--- a/cores/portduino/AsyncUDP.cpp
+++ b/cores/portduino/AsyncUDP.cpp
@@ -163,6 +163,14 @@ bool AsyncUDP::listenMulticast(const IPAddress addr, uint16_t port, uint8_t ttl)
         _fd = 0;
         return true;
     }
+    // Bind target differs by platform. Linux accepts binding to the multicast group
+    // address (uvAddr, and the SO_BROADCAST receive-fanout trick above depends on it).
+    // Darwin/BSD does not deliver looped-back multicast to sibling processes on the same
+    // host when the socket is bound to the group address, so bind to INADDR_ANY:port there
+    // instead. The uv_udp_set_membership() join above still filters received traffic.
+#if defined(__APPLE__)
+    uv_ip4_addr("0.0.0.0", port, (struct sockaddr_in *)&uvAddr);
+#endif
     if (uv_udp_bind(&_socket, (const struct sockaddr *)&uvAddr, 0) < 0) {
         close(_fd);
         _fd = 0;

--- a/cores/portduino/AsyncUDP.cpp
+++ b/cores/portduino/AsyncUDP.cpp
@@ -165,7 +165,7 @@ bool AsyncUDP::listenMulticast(const IPAddress addr, uint16_t port, uint8_t ttl)
     }
     // Bind target differs by platform. Linux accepts binding to the multicast group
     // address (uvAddr, and the SO_BROADCAST receive-fanout trick above depends on it).
-    // Darwin/BSD does not deliver looped-back multicast to sibling processes on the same
+    // Darwin does not deliver looped-back multicast to sibling processes on the same
     // host when the socket is bound to the group address, so bind to INADDR_ANY:port there
     // instead. The uv_udp_set_membership() join above still filters received traffic.
 #if defined(__APPLE__)

--- a/cores/portduino/AsyncUDP.cpp
+++ b/cores/portduino/AsyncUDP.cpp
@@ -169,7 +169,11 @@ bool AsyncUDP::listenMulticast(const IPAddress addr, uint16_t port, uint8_t ttl)
     // host when the socket is bound to the group address, so bind to INADDR_ANY:port there
     // instead. The uv_udp_set_membership() join above still filters received traffic.
 #if defined(__APPLE__)
-    uv_ip4_addr("0.0.0.0", port, (struct sockaddr_in *)&uvAddr);
+    if (uv_ip4_addr("0.0.0.0", port, (struct sockaddr_in *)&uvAddr) < 0) {
+        close(_fd);
+        _fd = 0;
+        return true;
+    }
 #endif
     if (uv_udp_bind(&_socket, (const struct sockaddr *)&uvAddr, 0) < 0) {
         close(_fd);


### PR DESCRIPTION
## Summary

`AsyncUDP::listenMulticast()` bound the UDP socket to the multicast group address (`224.0.0.69:port`). Linux loops those datagrams back to sibling processes on the same host, but Darwin/BSD does not — so two `meshtasticd` native nodes on one macOS host never exchanged NodeInfo over UDP multicast.

Bind to `INADDR_ANY:port` on `__APPLE__` instead. The `uv_udp_set_membership()` group join above still filters received traffic to the group. Linux is unchanged (still binds the group address, preserving the existing `SO_BROADCAST` receive-fanout behavior).

```c
#if defined(__APPLE__)
    uv_ip4_addr("0.0.0.0", port, (struct sockaddr_in *)&uvAddr);
#endif
    if (uv_udp_bind(&_socket, (const struct sockaddr *)&uvAddr, 0) < 0) {
```

## Test plan

- Rebuilt `native-macos` (meshtastic/firmware) with `-DHAS_UDP_MULTICAST=1` and confirmed two native nodes now mesh over `224.0.0.69:4403` — both node DBs cross-populate.
- Linux meshing remains green: verified two nodes in the official `meshtasticd` Docker image cross-populate and deliver a text message.
