### PR TITLE
Support Windows hosts

### DIFF
--- a/ArduinoCore-API/api/Common.h
+++ b/ArduinoCore-API/api/Common.h
@@ -83,7 +83,10 @@ void initVariant(void);
 // even though macOS is itself a Unix. Without the __APPLE__ guard the weak
 // `int main()` here clashes with main.cpp's `int main(int, char**)` under
 // Apple Clang's strict overload-of-`main` checking.
-#if !defined(__unix) && !defined(__APPLE__)
+// _WIN32 is excluded for the same reason: MinGW-w64 defines neither __unix nor
+// __APPLE__, so these would be declared, and `extern "C" int main()` then
+// conflicts with main.cpp's `int main(int, char**)`.
+#if !defined(__unix) && !defined(__APPLE__) && !defined(_WIN32)
 int atexit(void (*func)()) __attribute__((weak));
 int main() __attribute__((weak));
 #endif

--- a/cores/portduino/Arduino.h
+++ b/cores/portduino/Arduino.h
@@ -12,6 +12,20 @@
 #else
 #include "deprecated-avr-comp/avr/pgmspace.h"
 #endif
+
+#ifdef _WIN32
+// POSIX/BSD functions the Windows CRT lacks. Defined in Utility.cpp.
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+size_t strlcpy(char *dst, const char *src, size_t size);
+int setenv(const char *name, const char *value, int overwrite);
+char *stpcpy(char *dst, const char *src);
+#ifdef __cplusplus
+}
+#endif
+#endif // _WIN32
 #ifdef __cplusplus
 
 #include "HardwareSPI.h"
@@ -19,6 +33,36 @@
 #include "linux/LinuxHardwareI2C.h"
 
 extern HardwareSPI SPI;
+
+#ifdef _WIN32
+#include <cstdio>
+namespace arduino
+{
+// Windows is LLP64, so size_t is `unsigned long long` where LP64 Linux and macOS
+// have `unsigned long`. ArduinoCore-API's String stops at long/unsigned long, so
+// `someString + someSizeT` binds exactly on LP64 but is ambiguous here. Supply
+// the missing 64-bit overloads instead of casting at each call site, which would
+// truncate. Found by ADL; kept out of the vendored String.h to keep that tree
+// close to upstream.
+inline StringSumHelper &operator+(const StringSumHelper &lhs, unsigned long long num)
+{
+    StringSumHelper &a = const_cast<StringSumHelper &>(lhs);
+    char buf[24];
+    snprintf(buf, sizeof(buf), "%llu", num);
+    a.concat(buf);
+    return a;
+}
+
+inline StringSumHelper &operator+(const StringSumHelper &lhs, long long num)
+{
+    StringSumHelper &a = const_cast<StringSumHelper &>(lhs);
+    char buf[24];
+    snprintf(buf, sizeof(buf), "%lld", num);
+    a.concat(buf);
+    return a;
+}
+} // namespace arduino
+#endif // _WIN32
 
 using namespace arduino;
 
@@ -29,10 +73,18 @@ struct portduinoOptions {
 
 typedef HardwareI2C TwoWire; // Some Arduino ports use this terminology
 
-/** Map a pin number to an interrupt # 
+/** Map a pin number to an interrupt #
  * We always map 1:1
 */
 inline pin_size_t digitalPinToInterrupt(pin_size_t pinNumber) { return pinNumber; }
+
+#ifdef _WIN32
+/** Zero-argument random(). Common.h declares only random(max) / random(min, max);
+ * the no-argument form resolves to libc's random(3) on Linux and macOS, which the
+ * Windows CRT lacks. Defined in LinuxCommon.cpp.
+ */
+long random(void);
+#endif
 
 /** apps run under portduino can optionally define a portduinoSetup() to
  * use portduino specific init code (such as gpioBind) to setup portduino on

--- a/cores/portduino/AsyncUDP.cpp
+++ b/cores/portduino/AsyncUDP.cpp
@@ -1,3 +1,9 @@
+// Talks BSD sockets directly rather than going through libuv's UDP API, so it
+// doesn't build against Winsock. Nothing links it on Windows: the only consumer
+// is the firmware's UdpMulticastHandler, gated behind HAS_UDP_MULTICAST, which
+// neither the Windows nor macOS build sets.
+#ifndef _WIN32
+
 #include "AsyncUDP.h"
 #include <fcntl.h>
 #include <unistd.h>
@@ -275,3 +281,5 @@ void AsyncUDP::_doWrite(const uint8_t *data, size_t len, const IPAddress addr, u
         // FIXME: I don't know how to handle this error, better to just drop the packet.
     }
 }
+
+#endif // !_WIN32

--- a/cores/portduino/FS/vfs_api.cpp
+++ b/cores/portduino/FS/vfs_api.cpp
@@ -15,9 +15,47 @@
 #include "vfs_api.h"
 #include "logging.h"
 
-#ifndef ACCESSPERMS
-#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO) 
+#ifdef _WIN32
+#include <io.h>      // _commit(), _fileno()
+#include <windows.h> // MoveFileExA()
 #endif
+
+#ifndef ACCESSPERMS
+#ifdef _WIN32
+// Windows has no POSIX group/other permission bits, and the mode is ignored by
+// the single-argument mkdir below anyway.
+#define ACCESSPERMS 0
+#else
+#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
+#endif
+
+// MinGW's <sys/stat.h> declares only the single-argument mkdir(const char *).
+#ifdef _WIN32
+#define portduino_mkdir(path, mode) ::mkdir(path)
+#else
+#define portduino_mkdir(path, mode) ::mkdir(path, mode)
+#endif
+
+namespace {
+// The Arduino FS API has no text mode; every target treats file I/O as raw
+// bytes. The Windows CRT does not: fopen("w") without a "b" translates \n to
+// \r\n and back, silently corrupting the protobufs the firmware stores. Force
+// binary mode so Windows matches every other host.
+const char *vfsBinaryMode(const char *mode, char *buf, size_t bufLen)
+{
+#ifdef _WIN32
+    if (!mode || strchr(mode, 'b'))
+        return mode;
+    snprintf(buf, bufLen, "%sb", mode);
+    return buf;
+#else
+    (void)buf;
+    (void)bufLen;
+    return mode;
+#endif
+}
+} // namespace
 
 using namespace fs;
 
@@ -114,7 +152,15 @@ bool VFSImpl::rename(const char* pathFrom, const char* pathTo)
     }
     sprintf(temp1,"%s%s", _mountpoint, pathFrom);
     sprintf(temp2,"%s%s", _mountpoint, pathTo);
+#ifdef _WIN32
+    // POSIX rename() replaces an existing destination; the Windows CRT's fails
+    // with EEXIST. Callers rely on the POSIX behaviour: the firmware's SafeFile
+    // renames a .tmp over the live prefs file precisely because that swap is
+    // atomic, so use MoveFileEx rather than remove()-then-rename().
+    auto rc = MoveFileExA(temp1, temp2, MOVEFILE_REPLACE_EXISTING) ? 0 : -1;
+#else
     auto rc = ::rename(temp1, temp2);
+#endif
     free(temp1);
     free(temp2);
     return rc == 0;
@@ -177,7 +223,7 @@ bool VFSImpl::mkdir(const char *path)
         return false;
     }
     sprintf(temp,"%s%s", _mountpoint, path);
-    auto rc = ::mkdir(temp, ACCESSPERMS);
+    auto rc = portduino_mkdir(temp, ACCESSPERMS);
     free(temp);
     return rc == 0;
 }
@@ -233,6 +279,9 @@ VFSFileImpl::VFSFileImpl(VFSImpl* fs, const char* path, const char* mode)
         free(temp);
         return;
     }
+
+    char modeBuf[8];
+    mode = vfsBinaryMode(mode, modeBuf, sizeof(modeBuf));
 
     if(!stat(temp, &_stat)) {
         //file found
@@ -346,7 +395,12 @@ void VFSFileImpl::flush()
     }
     fflush(_f);
     // workaround for https://github.com/espressif/arduino-esp32/issues/1293
+#ifdef _WIN32
+    // The CRT spells fsync() as _commit(), taking the same underlying fd.
+    _commit(_fileno(_f));
+#else
     fsync(fileno(_f));
+#endif
 }
 
 bool VFSFileImpl::seek(uint32_t pos, SeekMode mode)
@@ -397,9 +451,14 @@ FileImplPtr VFSFileImpl::openNextFile(const char* mode)
     if(file == NULL) {
         return FileImplPtr();
     }
+#ifndef _WIN32
+    // Skip entries that aren't a regular file, directory, or symlink. MinGW's
+    // <dirent.h> has no d_type, and Windows directories only contain files,
+    // directories and reparse points, so there is nothing to exclude there.
     if(file->d_type != DT_REG && file->d_type != DT_DIR && file->d_type != DT_LNK) {
         return openNextFile(mode);
     }
+#endif
     String fname = String(file->d_name);
     String name = String(_path);
     if(!fname.startsWith("/") && !name.endsWith("/")) {

--- a/cores/portduino/Utility.cpp
+++ b/cores/portduino/Utility.cpp
@@ -7,6 +7,42 @@
 #include <stdio.h>
 #include <stdarg.h>
 
+#ifdef _WIN32
+#include <cstdlib>
+#include <cstring>
+
+// Declared in Arduino.h.
+
+// Returns the length of src so callers can detect truncation, and always
+// NUL-terminates when size > 0, matching the BSD contract.
+extern "C" size_t strlcpy(char *dst, const char *src, size_t size)
+{
+    size_t len = strlen(src);
+    if (size > 0) {
+        size_t copy = len < size - 1 ? len : size - 1;
+        memcpy(dst, src, copy);
+        dst[copy] = '\0';
+    }
+    return len;
+}
+
+// _putenv_s always overwrites, so honour `overwrite == 0` explicitly.
+extern "C" int setenv(const char *name, const char *value, int overwrite)
+{
+    if (!overwrite && getenv(name))
+        return 0;
+    return _putenv_s(name, value) == 0 ? 0 : -1;
+}
+
+// strcpy() returning a pointer to dst's terminating NUL rather than its start.
+extern "C" char *stpcpy(char *dst, const char *src)
+{
+    size_t len = strlen(src);
+    memcpy(dst, src, len + 1);
+    return dst + len;
+}
+#endif // _WIN32
+
 void notImplemented(const char *msg) { printf("%s is not implemented\n", msg); }
 
 void portduinoError(const char *msg, ...) {

--- a/cores/portduino/linux/LinuxCommon.cpp
+++ b/cores/portduino/linux/LinuxCommon.cpp
@@ -26,6 +26,22 @@ void delayMicroseconds(unsigned int usec) {
 
 void yield(void) { sched_yield(); }
 
+#ifdef _WIN32
+// libc's random(3) doesn't exist on Windows. Compose several rand() draws rather
+// than forwarding to it directly: glibc's random() yields 31 bits while the
+// Windows CRT's RAND_MAX is 0x7FFF (15 bits), and callers assume the wider range
+// (apps draw nonces from this). Staying on rand() keeps the seeding contract
+// identical to the Linux build, where randomSeed() calls srand() and glibc's
+// srand() and srandom() are the same function.
+long random(void)
+{
+    unsigned long v = (unsigned long)rand();
+    v = (v << 15) ^ (unsigned long)rand();
+    v = (v << 15) ^ (unsigned long)rand();
+    return (long)(v & 0x7FFFFFFFUL);
+}
+#endif
+
 long random(long max) { return random(0, max); }
 
 long random(long min, long max) { 

--- a/cores/portduino/linux/LinuxSerial.cpp
+++ b/cores/portduino/linux/LinuxSerial.cpp
@@ -3,19 +3,49 @@
 //
 
 #include "LinuxSerial.h"
+#include <string>
+
+#include <stdio.h>
+
+// LinuxSerial drives a real UART through POSIX termios, which Windows has no
+// equivalent for (it would need the CreateFile/DCB/COMMTIMEOUTS API). SimSerial,
+// the console log sink the headless builds use, is portable and stays common.
+// On Windows LinuxSerial is stubbed so arduino::Serial1 still links; it just
+// reports "not connected" via operator bool().
+#ifndef _WIN32
+
 #include <fcntl.h> // Contains file controls like O_RDWR
 #include <errno.h> // Error integer and strerror() function
 #include <termios.h> // Contains POSIX terminal control definitions
 #include <unistd.h> // write(), read(), close()
-#include <string>
 #include <sys/ioctl.h>
 
-#include <stdio.h>
-
 struct termios tty;
+#endif // !_WIN32
+
 namespace arduino {
     LinuxSerial Serial1;
     SimSerial Serial;
+
+#ifdef _WIN32
+    // serial_port stays -1, so operator bool() reports the port as unusable.
+    void LinuxSerial::begin(unsigned long baudrate, uint16_t config) {}
+
+    int LinuxSerial::setPath(std::string serialPath) {
+        if (serialPath != "")
+            path = serialPath;
+        return 0;
+    }
+
+    void LinuxSerial::end() {}
+    int LinuxSerial::available(void) { return 0; }
+    int LinuxSerial::peek(void) { return -1; }
+    int LinuxSerial::read(void) { return -1; }
+    void LinuxSerial::flush(void) {}
+    size_t LinuxSerial::write(uint8_t c) { return 0; }
+    LinuxSerial::operator bool() { return false; }
+
+#else // !_WIN32
     // https://blog.mbedded.ninja/programming/operating-systems/linux/linux-serial-ports-using-c-cpp/
 
     void LinuxSerial::begin(unsigned long baudrate, uint16_t config) {
@@ -208,7 +238,7 @@ namespace arduino {
         return serial_port != -1;
     }
 
-
+#endif // !_WIN32
 
     //simulated serial for log output:
     void SimSerial::begin(unsigned long baudrate, uint16_t config) {

--- a/cores/portduino/main.cpp
+++ b/cores/portduino/main.cpp
@@ -3,12 +3,27 @@
 #include "PortduinoGPIO.h"
 #include <argp.h>
 #include <stdio.h>
-#include <ftw.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
 #include <cerrno>
 #include <iostream>
 #include <cstring>
+
+#ifdef _WIN32
+// No <ftw.h> on Windows; _mkdir()/_execv() come from the CRT headers below.
+#include <direct.h>
+#include <process.h>
+#include <filesystem>
+#include <sys/stat.h>
+#else
+#include <ftw.h>
+#include <sys/stat.h>
+#endif
+
+// Windows has no POSIX permission bits, so _mkdir() takes no mode.
+#ifdef _WIN32
+#define portduino_mkdir(path, mode) _mkdir(path)
+#else
+#define portduino_mkdir(path, mode) mkdir(path, mode)
+#endif
 
 /** # msecs to sleep each loop invocation.  FIXME - make this controlable via
  * config file or command line flags.
@@ -77,11 +92,32 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
 /*
  * Functions to remove contents of directory
- * Adapted from: https://stackoverflow.com/a/5467788 
- */ 
+ * Adapted from: https://stackoverflow.com/a/5467788
+ */
+#ifdef _WIN32
+// No nftw() on Windows. Deleting each entry under the root rather than the root
+// itself matches the POSIX path's `0 < ftwbuf->level` test.
+int rmrf(char *path)
+{
+    std::error_code ec;
+    for (const auto &entry : std::filesystem::directory_iterator(path, ec)) {
+        std::error_code rmEc;
+        std::filesystem::remove_all(entry.path(), rmEc);
+        if (rmEc) {
+            fprintf(stderr, "%s: %s\n", entry.path().string().c_str(), rmEc.message().c_str());
+            return -1;
+        }
+    }
+    if (ec) {
+        fprintf(stderr, "%s: %s\n", path, ec.message().c_str());
+        return -1;
+    }
+    return 0;
+}
+#else
 int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
 {
-    int rv = 0; 
+    int rv = 0;
     if (0 < ftwbuf->level)
       rv = remove(fpath);
     if (rv)
@@ -94,6 +130,7 @@ int rmrf(char *path)
 {
     return nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
 }
+#endif // _WIN32
 
 static struct argp argp = {options, parse_opt, args_doc, doc, children, 0, 0};
 
@@ -113,8 +150,15 @@ void portduinoSetOptions(portduinoOptions options) {
 }
 
 void reboot() {
+#ifdef _WIN32
+  // _execv() spawns a replacement and terminates this process rather than
+  // replacing the image in place, but the effect is the same restart.
+  int err = _execv(progArgv[0], progArgv);
+  printf("_execv() returned %i!\n", err);
+#else
   int err = execv(progArgv[0], progArgv);
   printf("execv() returned %i!\n", err);
+#endif
   std::cout << "error: " << std::strerror(errno) << '\n';
   exit(EXIT_FAILURE);
 }
@@ -143,10 +187,15 @@ int main(int argc, char *argv[]) {
       // create a default dir
 
       const char *homeDir = getenv("HOME");
+#ifdef _WIN32
+      // Windows doesn't set $HOME outside of MSYS/Cygwin shells.
+      if (!homeDir)
+        homeDir = getenv("USERPROFILE");
+#endif
       assert(homeDir);
 
       fsRoot += homeDir + String("/.portduino");
-      mkdir(fsRoot.c_str(), 0700);
+      portduino_mkdir(fsRoot.c_str(), 0700);
 
       const char *instanceName = "default";
       fsRoot += "/" + String(instanceName);
@@ -155,7 +204,7 @@ int main(int argc, char *argv[]) {
 
     printf("Portduino is starting, VFS root at %s\n", fsRoot.c_str());
 
-    int status = mkdir(fsRoot.c_str(), 0700);
+    int status = portduino_mkdir(fsRoot.c_str(), 0700);
     if (status != 0 && errno == EEXIST && args->erase) {
       // Remove contents of existing VFS root directory
       std::cout << "Erasing virtual Filesystem!" << std::endl;


### PR DESCRIPTION
Builds portduino on Windows with MinGW-w64 (MSYS2 UCRT64), alongside the existing
Linux and macOS hosts. POSIX behaviour is unchanged throughout: every change is
either behind `#ifdef _WIN32` or compiles to the call that was there before.

Part of a four-repo cascade adding a native Windows meshtasticd target. Depends
on Meshtastic/WiFi#7, already merged and pointed at here.

## Changes

**`main.cpp`** - no `<ftw.h>` on Windows, so `rmrf()` iterates the root's entries
with `std::filesystem`, matching the POSIX path's `0 < ftwbuf->level` test (the
contents go, the root stays). `_mkdir()` takes no mode, `_execv()` stands in for
`execv()`, and `$HOME` falls back to `$USERPROFILE`, which Windows does not set
outside MSYS/Cygwin shells. The unused `<sys/socket.h>` and `<sys/ioctl.h>`
includes are dropped.

**`FS/vfs_api.cpp`** - two silent-corruption fixes, both worth a close look:

* `fopen()` is forced to binary mode. The Arduino FS API has no text mode; every
  other target treats file I/O as raw bytes. The Windows CRT does not, and
  translates `\n` to `\r\n` without a `"b"`. Consumers storing binary payloads
  get them mangled: meshtasticd's protobuf prefs failed their readback hash.
* `rename()` becomes `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`. POSIX `rename()`
  replaces an existing destination; the CRT's fails with `EEXIST`. Callers rely
  on the POSIX behaviour, and meshtasticd's SafeFile renames a `.tmp` over the
  live file precisely because that swap is atomic, so this is not
  `remove()`-then-`rename()`.

Also `_commit()` for `fsync()`, and MinGW's `<dirent.h>` has no `d_type` (Windows
directories only hold files, directories and reparse points, so that filter has
nothing to exclude).

**`LinuxSerial.cpp`** - Windows has no termios, so `LinuxSerial` is stubbed and
`arduino::Serial1` still links, reporting "not connected" via `operator bool()`.
`SimSerial`, the console log sink the headless builds actually use, is portable
and stays common. A real UART would need the CreateFile/DCB/COMMTIMEOUTS API.

**`AsyncUDP.cpp`** - guarded out. It talks BSD sockets directly rather than
libuv's UDP API, and nothing links it on Windows: the only consumer is gated
behind `HAS_UDP_MULTICAST`, which neither the Windows nor macOS build sets.
Porting it to Winsock is what UDP multicast on Windows would take.

**`Arduino.h` / `Utility.cpp`** - `strlcpy()`, `setenv()` and `stpcpy()`, none of
which the Windows CRT has. Plus String `operator+` overloads for `long long` and
`unsigned long long`: Windows is LLP64, so `size_t` is `unsigned long long` and
`someString + someSizeT` is ambiguous where it binds exactly on LP64. The
overloads live here rather than in the vendored `ArduinoCore-API/api/String.h`,
to keep that tree close to upstream; ADL finds them since `StringSumHelper` is in
`namespace arduino`. Casting at each call site was the alternative and would
truncate a `size_t` on Win64.

**`LinuxCommon.cpp`** - the zero-argument `random()`, which resolves to libc on
Linux and macOS. It composes several `rand()` draws rather than returning
`rand()` directly: the Windows CRT's `RAND_MAX` is 15 bits against glibc
`random()`'s 31, and callers assume the wider range. Staying on `rand()` keeps
the seeding contract identical, since `randomSeed()` calls `srand()` and glibc's
`srand()` and `srandom()` are the same function.

**`ArduinoCore-API/api/Common.h`** - one-line guard, for the same reason
`__APPLE__` is already excluded above it. MinGW-w64 defines neither `__unix` nor
`__APPLE__`, so the weak `extern "C" int main()` gets declared and conflicts with
`main.cpp`'s `int main(int, char**)`.

## Testing

Built and run on Windows 11 with MSYS2 UCRT64 (gcc 16.1.0) via the meshtasticd
`native-windows` env: a static PE32+ binary boots headless in SimRadio mode,
reaches `API server listen on TCP port 4403`, and round-trips its protobuf prefs
across restarts (which is what exercises the binary-mode and MoveFileEx fixes).
Linux and macOS are unchanged and untested by this PR.
