### PR TITLE
fix(fs): rmdir() removed nothing, it called unlink()

### DIFF
--- a/cores/portduino/FS/vfs_api.cpp
+++ b/cores/portduino/FS/vfs_api.cpp
@@ -251,7 +251,9 @@ bool VFSImpl::rmdir(const char *path)
         return false;
     }
     sprintf(temp,"%s%s", _mountpoint, path);
-    auto rc = unlink(temp);
+    // unlink() cannot remove a directory (EISDIR on Linux, EACCES on Windows), so this always
+    // failed. Qualified: an unqualified rmdir() would resolve to this member and recurse.
+    auto rc = ::rmdir(temp);
     free(temp);
     return rc == 0;
 }


### PR DESCRIPTION
`VFSImpl::rmdir()` built the native path and then passed it to `unlink()`, which cannot remove a directory. Measured on both hosts:

| | `unlink(empty dir)` | `rmdir(empty dir)` |
| --- | --- | --- |
| Linux (glibc) | -1, EISDIR, directory still exists | 0, gone |
| Windows (UCRT64) | -1, EACCES, directory still exists | 0, gone |

So the call always failed. `FSCom.rmdir()` has never removed a directory on any portduino platform, and `rmDir()` leaves the whole tree behind.

## Parity with the other backends

This file is a port of arduino-esp32's `libraries/FS/src/vfs_api.cpp`, which uses `::rmdir()` at the same spot:

```cpp
  // Let rmdir() handle the error if directory doesn't exist
  auto rc = ::rmdir(temp);
```

The nRF52 `Adafruit_LittleFS::rmdir()` backend calls `lfs_remove()`, which removes an empty directory and returns `LFS_ERR_NOTEMPTY` otherwise. Both platforms therefore implement "remove an empty directory". portduino was the only backend that did not, so firmware written against the Arduino FS API behaved differently there.

The call is qualified as `::rmdir` because an unqualified `rmdir()` inside `VFSImpl::rmdir` resolves to the member function and recurses. That is the likely reason `unlink()` was reached for originally.

## Verification

Against the meshtastic firmware native test suite on Windows, `test_fscommon_getfiles` previously passed only against a clean tree and failed on every later run: the directories its depth-limit case creates survived `setUp()`'s `rmDir()`, so `getFiles()` reported a depth truncation and the "not limited" case failed.

With this change, seeding the stale tree first, the suite passes with the stale tree present, passes on two consecutive runs, and leaves zero entries behind each time.

Linux does not currently show the failure because each suite there runs in its own scratch `$HOME`, so leftovers never survive into a later run, and within a single run the directory-creating case happens to run after the directory-sensitive one. The underlying defect is the same on both platforms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directory removal so directories can be deleted correctly.
  * Prevented directory deletion from incorrectly using file removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->